### PR TITLE
FIX: Dependencies fra Dependabot - må ha placeholder for swagger-vers…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
             UNNTAK: feature-brancher og lokalt
         -->
         <felles.version>1.4.2-20191218142505-f63b3cc</felles.version>
-        <fp-kontrakter.version>5.1_20191223122121_321af1f</fp-kontrakter.version>
+        <fp-kontrakter.version>5.1_20200110145005_4852947</fp-kontrakter.version>
 
         <!-- Eksterne tjenestekontrakter -->
         <person-api-feed.version>1.1.0</person-api-feed.version>
@@ -50,10 +50,11 @@
         <resteasy-validator-provider.version>3.9.3.Final</resteasy-validator-provider.version>
         <weld-web.version>3.1.3.Final</weld-web.version>
         <javax.el.version>3.0.1-b11</javax.el.version>
+        <swagger.version>2.1.1</swagger.version>
 
         <!-- Transitive avh. versjoner for å sikre unikhet (enforcer dependencyConvergence).  Skal ikke benyttes direkte av vår egen kode. -->
         <joda-time.version>2.10.5</joda-time.version>
-        <ow2.asm.version>7.2</ow2.asm.version>
+        <ow2.asm.version>7.3.1</ow2.asm.version>
         <owaspencoder.version>1.2.2</owaspencoder.version>
         <javaslang.version>2.0.6</javaslang.version>
         <swagger.spec-parser.version>1.0.49</swagger.spec-parser.version>
@@ -271,12 +272,12 @@
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-jaxrs2</artifactId>
-                <version>2.1.0</version>
+                <version>${swagger.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-core</artifactId>
-                <version>2.1.0</version>
+                <version>${swagger.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.github.swagger2markup</groupId>
@@ -286,7 +287,7 @@
             <dependency>
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-annotations</artifactId>
-                <version>2.1.0</version>
+                <version>${swagger.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.javaslang</groupId>


### PR DESCRIPTION
…jonen, ellers vil hvert enkelt forslag fra Dependabot feile i sitt Jenkins-bygg, siden det blir inkonsistens når det er en ny og resten er gamle. Det blir også en PR per Swagger-dependency, i stedet for en samlet for alle.