### PR TITLE
TFP-2847: Ved mottak av hendelser fra person-feed vil det nå gjøres e…

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/domain/HendelseRepository.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/domain/HendelseRepository.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import no.nav.foreldrepenger.abonnent.kodeverdi.FeedKode;
+import no.nav.foreldrepenger.abonnent.kodeverdi.HendelseType;
 import no.nav.foreldrepenger.abonnent.kodeverdi.HåndtertStatusType;
 import no.nav.vedtak.felles.jpa.VLPersistenceUnit;
 
@@ -173,5 +174,18 @@ public class HendelseRepository {
             return Optional.empty();
         }
         return Optional.of(resultater.get(0));
+    }
+
+    public List<InngåendeHendelse> finnAlleHendelserFraSisteUkeAvType(HendelseType hendelseType, FeedKode feedKode) {
+        TypedQuery<InngåendeHendelse> query = entityManager.createQuery(
+                "from InngåendeHendelse where feedKode = :feedKode " + //$NON-NLS-1$
+                        "and opprettetTidspunkt >= :opprettetTidspunkt " + //$NON-NLS-1$
+                        "and payload != null " + //$NON-NLS-1$
+                        "and type = :type ", InngåendeHendelse.class); //$NON-NLS-1$
+        query.setParameter(FEED_KODE, feedKode);
+        query.setParameter("opprettetTidspunkt", LocalDateTime.now().minusDays(7));
+        query.setParameter("type", hendelseType);
+
+        return query.getResultList();
     }
 }

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/poller/FeedPollerManager.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/poller/FeedPollerManager.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 
 import no.nav.foreldrepenger.abonnent.felles.NamedThreadFactory;
 import no.nav.foreldrepenger.abonnent.kodeverdi.FeedKode;
+import no.nav.foreldrepenger.abonnent.pdl.PdlFeatureToggleTjeneste;
 import no.nav.vedtak.apptjeneste.AppServiceHandler;
 import no.nav.vedtak.util.Tuple;
 
@@ -32,6 +33,8 @@ public class FeedPollerManager implements AppServiceHandler {
     private static final Logger log = LoggerFactory.getLogger(FeedPollerManager.class);
 
     private FeedPollerRepositoryImpl feedPollerRepository;
+
+    private PdlFeatureToggleTjeneste pdlFeatureToggleTjeneste;
 
     /**
      * Prefix every thread in pool with given name.
@@ -59,16 +62,21 @@ public class FeedPollerManager implements AppServiceHandler {
     }
 
     @Inject
-    public FeedPollerManager(FeedPollerRepositoryImpl feedPollerRepository, @Any Instance<FeedPoller> feedPollers) {
+    public FeedPollerManager(FeedPollerRepositoryImpl feedPollerRepository, @Any Instance<FeedPoller> feedPollers, PdlFeatureToggleTjeneste pdlFeatureToggleTjeneste) {
         Objects.requireNonNull(feedPollerRepository, "feedPollerRepository"); //$NON-NLS-1$
         Objects.requireNonNull(feedPollers, "feedPollers"); //$NON-NLS-1$
         this.feedPollerRepository = feedPollerRepository;
         this.feedPollers = feedPollers;
+        this.pdlFeatureToggleTjeneste = pdlFeatureToggleTjeneste;
     }
 
     @Override
     public synchronized void start() {
-        startPollerThread();
+        if (pdlFeatureToggleTjeneste.skalKonsumerePf()) {
+            startPollerThread();
+        } else {
+            log.info("Person-feed er deaktivert i dette clusteret");
+        }
     }
 
     @Override

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/tps/PdlDødHendelseTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/tps/PdlDødHendelseTjeneste.java
@@ -26,6 +26,10 @@ public class PdlDødHendelseTjeneste implements HendelseTjeneste<PdlDødHendelse
 
     private PersonTjeneste personTjeneste;
 
+    public PdlDødHendelseTjeneste() {
+        // CDI
+    }
+
     @Inject
     public PdlDødHendelseTjeneste(PersonTjeneste personTjeneste) {
         this.personTjeneste = personTjeneste;

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/tps/PdlDødfødselHendelseTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/tps/PdlDødfødselHendelseTjeneste.java
@@ -25,6 +25,10 @@ public class PdlDødfødselHendelseTjeneste implements HendelseTjeneste<PdlDødf
 
     private PersonTjeneste personTjeneste;
 
+    public PdlDødfødselHendelseTjeneste() {
+        // CDI
+    }
+
     @Inject
     public PdlDødfødselHendelseTjeneste(PersonTjeneste personTjeneste) {
         this.personTjeneste = personTjeneste;

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/tps/PdlFødselHendelseTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/tps/PdlFødselHendelseTjeneste.java
@@ -27,6 +27,10 @@ public class PdlFødselHendelseTjeneste implements HendelseTjeneste<PdlFødselHe
 
     private PersonTjeneste personTjeneste;
 
+    public PdlFødselHendelseTjeneste() {
+        // CDI
+    }
+
     @Inject
     public PdlFødselHendelseTjeneste(PersonTjeneste personTjeneste) {
         this.personTjeneste = personTjeneste;

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/tps/PdlLanseringTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/tps/PdlLanseringTjeneste.java
@@ -1,0 +1,113 @@
+package no.nav.foreldrepenger.abonnent.feed.tps;
+
+import java.util.List;
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.abonnent.feed.domain.DødHendelsePayload;
+import no.nav.foreldrepenger.abonnent.feed.domain.DødfødselHendelsePayload;
+import no.nav.foreldrepenger.abonnent.feed.domain.FødselHendelsePayload;
+import no.nav.foreldrepenger.abonnent.feed.domain.HendelseRepository;
+import no.nav.foreldrepenger.abonnent.feed.domain.InngåendeHendelse;
+import no.nav.foreldrepenger.abonnent.feed.domain.PdlDødHendelsePayload;
+import no.nav.foreldrepenger.abonnent.feed.domain.PdlDødfødselHendelsePayload;
+import no.nav.foreldrepenger.abonnent.feed.domain.PdlFødselHendelsePayload;
+import no.nav.foreldrepenger.abonnent.felles.JsonMapper;
+import no.nav.foreldrepenger.abonnent.kodeverdi.FeedKode;
+import no.nav.foreldrepenger.abonnent.kodeverdi.HendelseType;
+import no.nav.tjenester.person.feed.common.v1.FeedEntry;
+
+/**
+ * Midlertidig tjeneste for å unngå duplikater i de dagene vi konsumerer både TPS- og PDL- hendelser.
+ */
+@ApplicationScoped
+public class PdlLanseringTjeneste {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PdlLanseringTjeneste.class);
+
+    private FødselsmeldingOpprettetHendelseTjeneste fødselsmeldingOpprettetHendelseTjeneste;
+    private DødsmeldingOpprettetHendelseTjeneste dødsmeldingOpprettetHendelseTjeneste;
+    private DødfødselOpprettetHendelseTjeneste dødfødselOpprettetHendelseTjeneste;
+    private PdlFødselHendelseTjeneste pdlFødselHendelseTjeneste;
+    private PdlDødHendelseTjeneste pdlDødHendelseTjeneste;
+    private PdlDødfødselHendelseTjeneste pdlDødfødselHendelseTjeneste;
+    private HendelseRepository hendelseRepository;
+
+    public PdlLanseringTjeneste() {
+        // CDI
+    }
+
+    @Inject
+    public PdlLanseringTjeneste(@Any FødselsmeldingOpprettetHendelseTjeneste fødselsmeldingOpprettetHendelseTjeneste,
+                                @Any DødsmeldingOpprettetHendelseTjeneste dødsmeldingOpprettetHendelseTjeneste,
+                                @Any DødfødselOpprettetHendelseTjeneste dødfødselOpprettetHendelseTjeneste,
+                                @Any PdlFødselHendelseTjeneste pdlFødselHendelseTjeneste,
+                                @Any PdlDødHendelseTjeneste pdlDødHendelseTjeneste,
+                                @Any PdlDødfødselHendelseTjeneste pdlDødfødselHendelseTjeneste,
+                                HendelseRepository hendelseRepository) {
+        this.fødselsmeldingOpprettetHendelseTjeneste = fødselsmeldingOpprettetHendelseTjeneste;
+        this.dødsmeldingOpprettetHendelseTjeneste = dødsmeldingOpprettetHendelseTjeneste;
+        this.dødfødselOpprettetHendelseTjeneste = dødfødselOpprettetHendelseTjeneste;
+        this.pdlFødselHendelseTjeneste = pdlFødselHendelseTjeneste;
+        this.pdlDødHendelseTjeneste = pdlDødHendelseTjeneste;
+        this.pdlDødfødselHendelseTjeneste = pdlDødfødselHendelseTjeneste;
+        this.hendelseRepository = hendelseRepository;
+    }
+
+    public Optional<String> sjekkOmTpsHendelseErMottattFraPdlAllerede(FeedEntry feedEntry) {
+        HendelseType hendelseType = HendelseType.fraKodeDefaultUdefinert(feedEntry.getType());
+
+        if (HendelseType.FØDSELSMELDINGOPPRETTET.equals(hendelseType)) {
+            FødselHendelsePayload tpsPayload = fødselsmeldingOpprettetHendelseTjeneste.payloadFraString(JsonMapper.toJson(feedEntry));
+            List<InngåendeHendelse> pdlHendelser = hendelseRepository.finnAlleHendelserFraSisteUkeAvType(HendelseType.PDL_FØDSEL_OPPRETTET, FeedKode.PDL);
+            for (InngåendeHendelse pdlHendelse : pdlHendelser) {
+                PdlFødselHendelsePayload pdlPayload = pdlFødselHendelseTjeneste.payloadFraString(pdlHendelse.getPayload());
+                if (tpsPayload.getAktørIdBarn().isPresent() && pdlPayload.getAktørIdBarn().isPresent()) {
+                    Optional<Boolean> match = tpsPayload.getAktørIdBarn().get().stream()
+                            .map(aktørId -> pdlPayload.getAktørIdBarn().get().contains(aktørId)).findFirst();
+                    if (match.isPresent() && match.get()) {
+                        return Optional.of(pdlHendelse.getHendelseId());
+                    }
+                }
+            }
+
+        } else if (HendelseType.DØDSMELDINGOPPRETTET.equals(hendelseType)) {
+            DødHendelsePayload tpsPayload = dødsmeldingOpprettetHendelseTjeneste.payloadFraString(JsonMapper.toJson(feedEntry));
+            List<InngåendeHendelse> pdlHendelser = hendelseRepository.finnAlleHendelserFraSisteUkeAvType(HendelseType.PDL_DØD_OPPRETTET, FeedKode.PDL);
+            for (InngåendeHendelse pdlHendelse : pdlHendelser) {
+                PdlDødHendelsePayload pdlPayload = pdlDødHendelseTjeneste.payloadFraString(pdlHendelse.getPayload());
+                if (tpsPayload.getAktørId().isPresent() && pdlPayload.getAktørId().isPresent()) {
+                    Optional<Boolean> match = tpsPayload.getAktørId().get().stream()
+                            .map(aktørId -> pdlPayload.getAktørId().get().contains(aktørId)).findFirst();
+                    if (match.isPresent() && match.get()) {
+                        return Optional.of(pdlHendelse.getHendelseId());
+                    }
+                }
+            }
+
+        } else if (HendelseType.DØDFØDSELOPPRETTET.equals(hendelseType)) {
+            DødfødselHendelsePayload tpsPayload = dødfødselOpprettetHendelseTjeneste.payloadFraString(JsonMapper.toJson(feedEntry));
+            List<InngåendeHendelse> pdlHendelser = hendelseRepository.finnAlleHendelserFraSisteUkeAvType(HendelseType.PDL_DØDFØDSEL_OPPRETTET, FeedKode.PDL);
+            for (InngåendeHendelse pdlHendelse : pdlHendelser) {
+                PdlDødfødselHendelsePayload pdlPayload = pdlDødfødselHendelseTjeneste.payloadFraString(pdlHendelse.getPayload());
+                if (tpsPayload.getAktørId().isPresent() && pdlPayload.getAktørId().isPresent()) {
+                    Optional<Boolean> match = tpsPayload.getAktørId().get().stream()
+                            .map(aktørId -> pdlPayload.getAktørId().get().contains(aktørId)).findFirst();
+                    if (match.isPresent() && match.get()) {
+                        return Optional.of(pdlHendelse.getHendelseId());
+                    }
+                }
+            }
+
+        } else {
+            LOG.warn("Ukjent TPS hendelsetype {} mottatt", feedEntry.getType());
+        }
+        return Optional.empty();
+    }
+}

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/pdl/PdlFeatureToggleTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/pdl/PdlFeatureToggleTjeneste.java
@@ -14,9 +14,10 @@ import no.nav.vedtak.util.env.Environment;
 public class PdlFeatureToggleTjeneste {
 
     private static final Set<Cluster> SKAL_KONSUMERE_PDL_AKTIVERT = Set.of(Cluster.LOCAL, Cluster.DEV_FSS, Cluster.PROD_FSS);
-    private static final Set<Cluster> SKAL_LAGRE_PDL_AKTIVERT = Set.of(Cluster.LOCAL, Cluster.DEV_FSS);
+    private static final Set<Cluster> SKAL_LAGRE_PDL_AKTIVERT = Set.of(Cluster.LOCAL, Cluster.DEV_FSS, Cluster.PROD_FSS);
     private static final Set<Cluster> SKAL_GROVSORTERE_PDL_AKTIVERT = Set.of(Cluster.LOCAL, Cluster.DEV_FSS);
-    private static final Set<Cluster> SKAL_SENDE_PDL_AKTIVERT = Set.of(Cluster.LOCAL);
+    private static final Set<Cluster> SKAL_SENDE_PDL_OG_DUPLIKATSJEKKE_PF_AKTIVERT = Set.of(Cluster.LOCAL, Cluster.DEV_FSS);
+    private static final Set<Cluster> SKAL_KONSUMERE_PF_AKTIVERT = Set.of(Cluster.LOCAL, Cluster.DEV_FSS, Cluster.PROD_FSS);
     private static final Cluster CLUSTER = Environment.current().getCluster();
 
     public boolean skalKonsumerePdl() {
@@ -31,7 +32,11 @@ public class PdlFeatureToggleTjeneste {
         return SKAL_GROVSORTERE_PDL_AKTIVERT.contains(CLUSTER);
     }
 
-    public boolean skalSendePdl() {
-        return SKAL_SENDE_PDL_AKTIVERT.contains(CLUSTER);
+    public boolean skalSendePdlOgDuplikatsjekkePf() {
+        return SKAL_SENDE_PDL_OG_DUPLIKATSJEKKE_PF_AKTIVERT.contains(CLUSTER);
+    }
+
+    public boolean skalKonsumerePf() {
+        return SKAL_KONSUMERE_PF_AKTIVERT.contains(CLUSTER);
     }
 }

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/pdl/PdlLeesahHendelseProperties.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/pdl/PdlLeesahHendelseProperties.java
@@ -53,13 +53,12 @@ public class PdlLeesahHendelseProperties {
         this.password = password;
         this.trustStorePath = trustStorePath;
         this.trustStorePassword = trustStorePassword;
-
-        String namespace = Environment.current().getNamespace().getNamespace();
-        LOG.info("Namespace fra Environment: {}", namespace); //TODO(JEJ) Fjerne når testet i Q
-        if (namespace == null || namespace.isBlank()) {
-            namespace = getEnvVar("NAIS_NAMESPACE", "default");
+        String naisAppName = Environment.current().getProperty("NAIS_APP_NAME");
+        if (naisAppName == null || naisAppName.isBlank()) {
+            LOG.info("Funker ikke å hente NAIS_APP_NAME fra environment - bør endres tilbake til System.getenv()"); //TODO(JEJ): Fjerne når testet på miljø
+            naisAppName = "fpabonnent";
         }
-        this.applicationId = getEnvVar("NAIS_APP_NAME", "fpabonnent") + "-" + namespace;
+        this.applicationId = naisAppName + "-" + Environment.current().getNamespace().getNamespace();
     }
 
     public Topic<String, Personhendelse> getTopic() {
@@ -154,10 +153,5 @@ public class PdlLeesahHendelseProperties {
             }
         }
         return serde;
-    }
-
-    private String getEnvVar(String key, String defaultValue) {
-        String val = System.getenv(key);
-        return (val == null) ? defaultValue : val;
     }
 }

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/task/SendHendelseTask.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/task/SendHendelseTask.java
@@ -56,7 +56,7 @@ public class SendHendelseTask implements ProsessTaskHandler {
         HendelserDataWrapper dataWrapper = new HendelserDataWrapper(prosessTaskData);
         HendelsePayload hendelsePayload = getHendelsePayload(dataWrapper);
 
-        if (!HendelseType.fraKode(hendelsePayload.getType()).erPdlHendelse() || pdlFeatureToggleTjeneste.skalSendePdl()) {
+        if (!HendelseType.fraKode(hendelsePayload.getType()).erPdlHendelse() || pdlFeatureToggleTjeneste.skalSendePdlOgDuplikatsjekkePf()) {
             hendelseConsumer.sendHendelse(hendelsePayload);
             inngåendeHendelseTjeneste.oppdaterHendelseSomSendtNå(hendelsePayload);
             LOGGER.info("Sendt hendelse: [{}] til FPSAK.", hendelsePayload.getHendelseId());

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/tjenester/InngåendeHendelseTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/tjenester/InngåendeHendelseTjeneste.java
@@ -56,7 +56,8 @@ public class InngåendeHendelseTjeneste {
             if (!relevanteHendelseIder.contains(entry.getKey())) {
                 InngåendeHendelse inngåendeHendelse = entry.getValue();
                 hendelseRepository.oppdaterHåndtertStatus(inngåendeHendelse, HåndtertStatusType.HÅNDTERT);
-                hendelseRepository.fjernPayload(inngåendeHendelse);
+                //TODO(JEJ): Kommentere inn slik at vi fjerner payload når vi har sett at det fungerer (+ bestille patch til null på gamle):
+                //hendelseRepository.fjernPayload(inngåendeHendelse);
             }
         }
     }

--- a/domene/src/test/java/no/nav/foreldrepenger/abonnent/feed/poller/FeedPollerManagerTest.java
+++ b/domene/src/test/java/no/nav/foreldrepenger/abonnent/feed/poller/FeedPollerManagerTest.java
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 
 import no.nav.foreldrepenger.abonnent.feed.domain.InputFeed;
 import no.nav.foreldrepenger.abonnent.kodeverdi.FeedKode;
+import no.nav.foreldrepenger.abonnent.pdl.PdlFeatureToggleTjeneste;
 import no.nav.vedtak.felles.testutilities.cdi.CdiRunner;
 
 @RunWith(CdiRunner.class)
@@ -35,7 +36,7 @@ public class FeedPollerManagerTest {
         when(feedPollers.iterator()).thenReturn(iterator);
         when(iterator.hasNext()).thenReturn(true, false);
         when(iterator.next()).thenReturn(new TestFeedPoller());
-        manager = new FeedPollerManager(feedPollerRepositoryImpl, feedPollers);
+        manager = new FeedPollerManager(feedPollerRepositoryImpl, feedPollers, new PdlFeatureToggleTjeneste());
     }
 
     @Test

--- a/domene/src/test/java/no/nav/foreldrepenger/abonnent/feed/poller/TpsFeedPollerTest.java
+++ b/domene/src/test/java/no/nav/foreldrepenger/abonnent/feed/poller/TpsFeedPollerTest.java
@@ -24,8 +24,10 @@ import org.mockito.junit.MockitoRule;
 
 import no.nav.foreldrepenger.abonnent.feed.domain.HendelseRepository;
 import no.nav.foreldrepenger.abonnent.feed.domain.InputFeed;
+import no.nav.foreldrepenger.abonnent.feed.tps.PdlLanseringTjeneste;
 import no.nav.foreldrepenger.abonnent.feed.tps.TpsFeedPoller;
 import no.nav.foreldrepenger.abonnent.felles.JsonMapper;
+import no.nav.foreldrepenger.abonnent.pdl.PdlFeatureToggleTjeneste;
 import no.nav.tjenester.person.feed.common.v1.Feed;
 import no.nav.tjenester.person.feed.common.v1.FeedEntry;
 import no.nav.tjenester.person.feed.v2.Meldingstype;
@@ -46,13 +48,15 @@ public class TpsFeedPollerTest {
     private TpsFeedPoller poller;
     @Mock
     private InputFeed inputFeed;
+    @Mock
+    private PdlLanseringTjeneste pdlLanseringTjeneste;
 
     private URI startUri = URI.create(BASE_URL_FEED + "?sequenceId=1&pageSize=5");
     private URI endpoint = URI.create(BASE_URL_FEED);
 
     @Before
     public void setUp() {
-        poller = new TpsFeedPoller(endpoint, hendelseRepository, oidcRestClient, "5", "aktiv");
+        poller = new TpsFeedPoller(endpoint, hendelseRepository, oidcRestClient, "5", "aktiv", pdlLanseringTjeneste, new PdlFeatureToggleTjeneste());
         Mockito.clearInvocations(oidcRestClient);
     }
 
@@ -110,7 +114,7 @@ public class TpsFeedPollerTest {
     @Test
     public void skal_ikke_polle_feed_når_deaktivert() {
         // Arrange
-        poller = new TpsFeedPoller(endpoint, hendelseRepository, oidcRestClient, "5", "falsk");
+        poller = new TpsFeedPoller(endpoint, hendelseRepository, oidcRestClient, "5", "false", pdlLanseringTjeneste, new PdlFeatureToggleTjeneste());
 
         // Act
         poller.poll(inputFeed);

--- a/domene/src/test/java/no/nav/foreldrepenger/abonnent/tjenester/InngåendeHendelseTjenesteTest.java
+++ b/domene/src/test/java/no/nav/foreldrepenger/abonnent/tjenester/InngåendeHendelseTjenesteTest.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -75,6 +76,8 @@ public class InngåendeHendelseTjenesteTest {
         assertThat(resultat).isEmpty();
     }
 
+    //TODO(JEJ): Kommentere inn når payload fjernes igjen:
+    @Ignore
     @Test
     public void skal_markere_ikke_relevante_hendelser_som_håndterte_og_fjerne_payload() {
         // Arrange

--- a/domene/src/test/java/no/nav/foreldrepenger/abonnent/tjenester/TpsFeedPollerOgInngåendeHendelseTest.java
+++ b/domene/src/test/java/no/nav/foreldrepenger/abonnent/tjenester/TpsFeedPollerOgInngåendeHendelseTest.java
@@ -35,12 +35,14 @@ import no.nav.foreldrepenger.abonnent.feed.domain.InputFeed;
 import no.nav.foreldrepenger.abonnent.feed.tps.DødfødselOpprettetHendelseTjeneste;
 import no.nav.foreldrepenger.abonnent.feed.tps.DødsmeldingOpprettetHendelseTjeneste;
 import no.nav.foreldrepenger.abonnent.feed.tps.FødselsmeldingOpprettetHendelseTjeneste;
+import no.nav.foreldrepenger.abonnent.feed.tps.PdlLanseringTjeneste;
 import no.nav.foreldrepenger.abonnent.feed.tps.TpsFeedPoller;
 import no.nav.foreldrepenger.abonnent.felles.HendelseTjeneste;
 import no.nav.foreldrepenger.abonnent.felles.HendelseTjenesteProvider;
 import no.nav.foreldrepenger.abonnent.felles.JsonMapper;
 import no.nav.foreldrepenger.abonnent.kodeverdi.HendelseType;
 import no.nav.foreldrepenger.abonnent.kodeverdi.HåndtertStatusType;
+import no.nav.foreldrepenger.abonnent.pdl.PdlFeatureToggleTjeneste;
 import no.nav.tjenester.person.feed.common.v1.Feed;
 import no.nav.vedtak.felles.integrasjon.rest.OidcRestClient;
 
@@ -68,6 +70,9 @@ public class TpsFeedPollerOgInngåendeHendelseTest {
 
     private InngåendeHendelseTjeneste inngåendeHendelseTjeneste;
 
+    @Mock
+    private PdlLanseringTjeneste pdlLanseringTjeneste;
+
     @Before
     public void setUp() {
         HendelseTjenesteProvider hendelseTjenesteProvider = mock(HendelseTjenesteProvider.class);
@@ -81,7 +86,7 @@ public class TpsFeedPollerOgInngåendeHendelseTest {
         when(hendelseTjenesteProvider.finnTjeneste(eq(HendelseType.DØDFØDSELOPPRETTET), anyString()))
                 .thenReturn(dødfødselHendelseTjeneste);
 
-        poller = new TpsFeedPoller(endpoint, hendelseRepository, oidcRestClient, "5", "aktiv");
+        poller = new TpsFeedPoller(endpoint, hendelseRepository, oidcRestClient, "5", "aktiv", pdlLanseringTjeneste, new PdlFeatureToggleTjeneste());
         inngåendeHendelseTjeneste = new InngåendeHendelseTjeneste(hendelseRepository, hendelseTjenesteProvider);
         Mockito.clearInvocations(oidcRestClient);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <weld-web.version>3.1.4.Final</weld-web.version>
         <javax.el.version>3.0.1-b11</javax.el.version>
         <swagger.version>2.1.2</swagger.version>
-        <swagger-ui.version>3.26.0</swagger-ui.version>
+        <swagger-ui.version>3.26.1</swagger-ui.version>
         <kafka.version>2.5.0</kafka.version>
         <avro.version>1.9.2</avro.version>
         <confluent.version>5.5.0</confluent.version>
@@ -474,7 +474,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>flatten-maven-plugin</artifactId>
-                    <version>1.2.2</version>
+                    <version>1.2.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>

--- a/web/src/main/resources/web/swagger/index.html
+++ b/web/src/main/resources/web/swagger/index.html
@@ -4,9 +4,9 @@
 <head>
   <meta charset="UTF-8">
   <title>Swagger UI</title>
-  <link rel="stylesheet" type="text/css" href="../swagger-ui/3.26.0/swagger-ui.css" >
-  <link rel="icon" type="image/png" href="../swagger-ui/3.26.0/favicon-32x32.png" sizes="32x32" />
-  <link rel="icon" type="image/png" href="../swagger-ui/3.26.0/favicon-16x16.png" sizes="16x16" />
+  <link rel="stylesheet" type="text/css" href="../swagger-ui/3.26.1/swagger-ui.css" >
+  <link rel="icon" type="image/png" href="../swagger-ui/3.26.1/favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="../swagger-ui/3.26.1/favicon-16x16.png" sizes="16x16" />
   <style>
     html
     {
@@ -33,8 +33,8 @@
 <body>
 <div id="swagger-ui"></div>
 
-<script src="../swagger-ui/3.26.0/swagger-ui-bundle.js"> </script>
-<script src="../swagger-ui/3.26.0/swagger-ui-standalone-preset.js"> </script>
+<script src="../swagger-ui/3.26.1/swagger-ui-bundle.js"> </script>
+<script src="../swagger-ui/3.26.1/swagger-ui-standalone-preset.js"> </script>
 <script>
   window.onload = function() {
     // Begin Swagger UI call region


### PR DESCRIPTION
…n sjekk mot databasen på samme hendelsetype for å sjekke om den allerede er mottatt fra PDL på samme aktørId. Det gjør at vi kan aktivere begge hendelseskildene samtidig, uten å få duplikater, i et lite overgangsvindu, før vi bytter helt over til PDL. Det er også innført toggle for konsumering av person-feed, slik at dette kan skrus fort av etter overgangsvinduet, uten å fjerne koden samtidig.