### PR TITLE
TFP-2847: Rettet feil der Person-feed hendelser ville blitt matchet m…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: daily
     time: "04:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 20
   ignore:
   - dependency-name: io.astefanutti.metrics.cdi:metrics-cdi
     versions:

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/domain/HendelseRepository.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/domain/HendelseRepository.java
@@ -181,9 +181,11 @@ public class HendelseRepository {
                 "from InngåendeHendelse where feedKode = :feedKode " + //$NON-NLS-1$
                         "and opprettetTidspunkt >= :opprettetTidspunkt " + //$NON-NLS-1$
                         "and payload != null " + //$NON-NLS-1$
+                        "and ((håndtertStatus = :håndtertStatus and sendtTidspunkt is not null) or (håndtertStatus != :håndtertStatus)) " + //$NON-NLS-1$
                         "and type = :type ", InngåendeHendelse.class); //$NON-NLS-1$
         query.setParameter(FEED_KODE, feedKode);
         query.setParameter("opprettetTidspunkt", LocalDateTime.now().minusDays(7));
+        query.setParameter(HÅNDTERT_STATUS, HåndtertStatusType.HÅNDTERT);
         query.setParameter("type", hendelseType);
 
         return query.getResultList();


### PR DESCRIPTION
…ot PDL-hendelser som bare er lagret ned, og ikke er forsøkt grovsortert eller sendt.