### PR TITLE
TFP-3114: Fødsler som skjedde for over to år siden blir nå filtrert b…

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/domain/HendelsePayload.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/domain/HendelsePayload.java
@@ -10,6 +10,8 @@ public abstract class HendelsePayload {
 
     protected String hendelseId;
 
+    protected String tidligereHendelseId;
+
     protected String type;
 
     protected String endringstype;
@@ -21,6 +23,10 @@ public abstract class HendelsePayload {
 
     public String getHendelseId() {
         return hendelseId;
+    }
+
+    public String getTidligereHendelseId() {
+        return tidligereHendelseId;
     }
 
     public String getType() {

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/domain/HendelseRepository.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/domain/HendelseRepository.java
@@ -60,9 +60,11 @@ public class HendelseRepository {
             TypedQuery<InngåendeHendelse> query = entityManager.createQuery(
                     "from InngåendeHendelse where håndtertStatus = :håndtertStatus " + //$NON-NLS-1$
                             "and håndteresEtterTidspunkt <= :håndteresEtterTidspunkt " + //$NON-NLS-1$
+                            "and feedKode = :feedKode " + //$NON-NLS-1$
                             SORTER_STIGENDE_PÅ_OPPRETTET_TIDSPUNKT, InngåendeHendelse.class);
             query.setParameter(HÅNDTERT_STATUS, HåndtertStatusType.MOTTATT);
             query.setParameter(HÅNDTERES_ETTER_TIDSPUNKT, LocalDateTime.now());
+            query.setParameter(FEED_KODE, FeedKode.TPS);
             hendelseLock.get().oppdaterSistLåstTidspunkt();
             return query.getResultList();
         }
@@ -146,6 +148,10 @@ public class HendelseRepository {
 
     public void oppdaterHåndtertStatus(InngåendeHendelse inngåendeHendelse, HåndtertStatusType håndtertStatus) {
         inngåendeHendelse.setHåndtertStatus(håndtertStatus);
+    }
+
+    public void oppdaterHåndteresEtterTidspunkt(InngåendeHendelse inngåendeHendelse, LocalDateTime håndteresEtterTidspunkt) {
+        inngåendeHendelse.setHåndteresEtterTidspunkt(håndteresEtterTidspunkt);
     }
 
     public void fjernPayload(InngåendeHendelse inngåendeHendelse) {

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/domain/InngåendeHendelse.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/domain/InngåendeHendelse.java
@@ -28,8 +28,8 @@ public class InngåendeHendelse extends BaseEntitet {
     @Column(name = "hendelse_id")
     private String hendelseId;
 
-    @Column(name = "kobling_id")
-    private Long koblingId;
+    @Column(name = "tidligere_hendelse_id")
+    private String tidligereHendelseId;
 
     @Convert(converter = FeedKode.KodeverdiConverter.class)
     @Column(name="feed_kode", nullable = false)
@@ -63,7 +63,7 @@ public class InngåendeHendelse extends BaseEntitet {
     private InngåendeHendelse(Builder builder) {
         this.id = builder.id;
         this.hendelseId = builder.hendelseId;
-        this.koblingId = builder.koblingId;
+        this.tidligereHendelseId = builder.tidligereHendelseId;
         this.feedKode = builder.feedKode;
         this.type = builder.type;
         this.payload = builder.payload;
@@ -81,8 +81,8 @@ public class InngåendeHendelse extends BaseEntitet {
         return hendelseId;
     }
 
-    public Long getKoblingId() {
-        return koblingId;
+    public String getTidligereHendelseId() {
+        return tidligereHendelseId;
     }
 
     public FeedKode getFeedKode() {
@@ -103,6 +103,10 @@ public class InngåendeHendelse extends BaseEntitet {
 
     public LocalDateTime getHåndteresEtterTidspunkt() {
         return håndteresEtterTidspunkt;
+    }
+
+    public void setHåndteresEtterTidspunkt(LocalDateTime håndteresEtterTidspunkt) {
+        this.håndteresEtterTidspunkt = håndteresEtterTidspunkt;
     }
 
     public HåndtertStatusType getHåndtertStatus() {
@@ -128,7 +132,7 @@ public class InngåendeHendelse extends BaseEntitet {
     public static class Builder {
         private Long id;
         private String hendelseId;
-        private Long koblingId;
+        private String tidligereHendelseId;
         private FeedKode feedKode;
         private HendelseType type;
         private String payload;
@@ -147,8 +151,8 @@ public class InngåendeHendelse extends BaseEntitet {
             return this;
         }
 
-        public Builder koblingId(Long koblingId) {
-            this.koblingId = koblingId;
+        public Builder tidligereHendelseId(String tidligereHendelseId) {
+            this.tidligereHendelseId = tidligereHendelseId;
             return this;
         }
 

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/domain/PdlDødHendelsePayload.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/domain/PdlDødHendelsePayload.java
@@ -24,6 +24,7 @@ public class PdlDødHendelsePayload extends HendelsePayload {
 
     private PdlDødHendelsePayload(PdlDødHendelsePayload.Builder builder) {
         this.hendelseId = builder.hendelseId;
+        this.tidligereHendelseId = builder.tidligereHendelseId;
         this.type = builder.type;
         this.endringstype = builder.endringstype;
         this.hendelseOpprettetTid = builder.hendelseOpprettetTid;
@@ -80,6 +81,8 @@ public class PdlDødHendelsePayload extends HendelsePayload {
 
         PdlDødHendelsePayload payload = (PdlDødHendelsePayload) o;
 
+        if (hendelseId != null ? !hendelseId.equals(payload.hendelseId) : payload.hendelseId != null) return false;
+        if (tidligereHendelseId != null ? !tidligereHendelseId.equals(payload.tidligereHendelseId) : payload.tidligereHendelseId != null) return false;
         if (type != null ? !type.equals(payload.type) : payload.type != null) return false;
         if (endringstype != null ? !endringstype.equals(payload.endringstype) : payload.endringstype != null) return false;
         if (hendelseOpprettetTid != null ? !hendelseOpprettetTid.equals(payload.hendelseOpprettetTid) : payload.hendelseOpprettetTid != null) return false;
@@ -89,7 +92,9 @@ public class PdlDødHendelsePayload extends HendelsePayload {
 
     @Override
     public int hashCode() {
-        int result = type != null ? type.hashCode() : 0;
+        int result = hendelseId != null ? hendelseId.hashCode() : 0;
+        result = 31 * result + (tidligereHendelseId != null ? tidligereHendelseId.hashCode() : 0);
+        result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (endringstype != null ? endringstype.hashCode() : 0);
         result = 31 * result + (hendelseOpprettetTid != null ? hendelseOpprettetTid.hashCode() : 0);
         result = 31 * result + (aktørId != null ? aktørId.hashCode() : 0);
@@ -99,6 +104,7 @@ public class PdlDødHendelsePayload extends HendelsePayload {
 
     public static class Builder {
         private String hendelseId;
+        private String tidligereHendelseId;
         private String type;
         private String endringstype;
         private LocalDateTime hendelseOpprettetTid;
@@ -107,6 +113,11 @@ public class PdlDødHendelsePayload extends HendelsePayload {
 
         public Builder hendelseId(String hendelseId) {
             this.hendelseId = hendelseId;
+            return this;
+        }
+
+        public Builder tidligereHendelseId(String tidligereHendelseId) {
+            this.tidligereHendelseId = tidligereHendelseId;
             return this;
         }
 

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/domain/PdlDødfødselHendelsePayload.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/domain/PdlDødfødselHendelsePayload.java
@@ -24,6 +24,7 @@ public class PdlDødfødselHendelsePayload extends HendelsePayload {
 
     private PdlDødfødselHendelsePayload(Builder builder) {
         this.hendelseId = builder.hendelseId;
+        this.tidligereHendelseId = builder.tidligereHendelseId;
         this.type = builder.type;
         this.endringstype = builder.endringstype;
         this.hendelseOpprettetTid = builder.hendelseOpprettetTid;
@@ -80,8 +81,8 @@ public class PdlDødfødselHendelsePayload extends HendelsePayload {
 
         PdlDødfødselHendelsePayload payload = (PdlDødfødselHendelsePayload) o;
 
-        if (hendelseId != null ? !hendelseId.equals(payload.hendelseId) : payload.hendelseId != null)
-            return false;
+        if (hendelseId != null ? !hendelseId.equals(payload.hendelseId) : payload.hendelseId != null) return false;
+        if (tidligereHendelseId != null ? !tidligereHendelseId.equals(payload.tidligereHendelseId) : payload.tidligereHendelseId != null) return false;
         if (type != null ? !type.equals(payload.type) : payload.type != null) return false;
         if (endringstype != null ? !endringstype.equals(payload.endringstype) : payload.endringstype != null) return false;
         if (hendelseOpprettetTid != null ? !hendelseOpprettetTid.equals(payload.hendelseOpprettetTid) : payload.hendelseOpprettetTid != null) return false;
@@ -92,6 +93,7 @@ public class PdlDødfødselHendelsePayload extends HendelsePayload {
     @Override
     public int hashCode() {
         int result = hendelseId != null ? hendelseId.hashCode() : 0;
+        result = 31 * result + (tidligereHendelseId != null ? tidligereHendelseId.hashCode() : 0);
         result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (endringstype != null ? endringstype.hashCode() : 0);
         result = 31 * result + (hendelseOpprettetTid != null ? hendelseOpprettetTid.hashCode() : 0);
@@ -102,6 +104,7 @@ public class PdlDødfødselHendelsePayload extends HendelsePayload {
 
     public static class Builder {
         private String hendelseId;
+        private String tidligereHendelseId;
         private String type;
         private String endringstype;
         private LocalDateTime hendelseOpprettetTid;
@@ -110,6 +113,11 @@ public class PdlDødfødselHendelsePayload extends HendelsePayload {
 
         public Builder hendelseId(String hendelseId) {
             this.hendelseId = hendelseId;
+            return this;
+        }
+
+        public Builder tidligereHendelseId(String tidligereHendelseId) {
+            this.tidligereHendelseId = tidligereHendelseId;
             return this;
         }
 

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/domain/PdlFødselHendelsePayload.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/domain/PdlFødselHendelsePayload.java
@@ -25,6 +25,7 @@ public class PdlFødselHendelsePayload extends HendelsePayload {
 
     private PdlFødselHendelsePayload(Builder builder) {
         this.hendelseId = builder.hendelseId;
+        this.tidligereHendelseId = builder.tidligereHendelseId;
         this.type = builder.type;
         this.endringstype = builder.endringstype;
         this.hendelseOpprettetTid = builder.hendelseOpprettetTid;
@@ -86,8 +87,8 @@ public class PdlFødselHendelsePayload extends HendelsePayload {
 
         PdlFødselHendelsePayload payload = (PdlFødselHendelsePayload) o;
 
-        if (hendelseId != null ? !hendelseId.equals(payload.hendelseId) : payload.hendelseId != null)
-            return false;
+        if (hendelseId != null ? !hendelseId.equals(payload.hendelseId) : payload.hendelseId != null) return false;
+        if (tidligereHendelseId != null ? !tidligereHendelseId.equals(payload.tidligereHendelseId) : payload.tidligereHendelseId != null) return false;
         if (type != null ? !type.equals(payload.type) : payload.type != null) return false;
         if (endringstype != null ? !endringstype.equals(payload.endringstype) : payload.endringstype != null) return false;
         if (hendelseOpprettetTid != null ? !hendelseOpprettetTid.equals(payload.hendelseOpprettetTid) : payload.hendelseOpprettetTid != null) return false;
@@ -99,6 +100,7 @@ public class PdlFødselHendelsePayload extends HendelsePayload {
     @Override
     public int hashCode() {
         int result = hendelseId != null ? hendelseId.hashCode() : 0;
+        result = 31 * result + (tidligereHendelseId != null ? tidligereHendelseId.hashCode() : 0);
         result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (endringstype != null ? endringstype.hashCode() : 0);
         result = 31 * result + (hendelseOpprettetTid != null ? hendelseOpprettetTid.hashCode() : 0);
@@ -110,6 +112,7 @@ public class PdlFødselHendelsePayload extends HendelsePayload {
 
     public static class Builder {
         private String hendelseId;
+        private String tidligereHendelseId;
         private String type;
         private String endringstype;
         private LocalDateTime hendelseOpprettetTid;
@@ -119,6 +122,11 @@ public class PdlFødselHendelsePayload extends HendelsePayload {
 
         public Builder hendelseId(String hendelseId) {
             this.hendelseId = hendelseId;
+            return this;
+        }
+
+        public Builder tidligereHendelseId(String tidligereHendelseId) {
+            this.tidligereHendelseId = tidligereHendelseId;
             return this;
         }
 

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/tps/PdlDødHendelseTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/tps/PdlDødHendelseTjeneste.java
@@ -47,6 +47,7 @@ public class PdlDødHendelseTjeneste implements HendelseTjeneste<PdlDødHendelse
 
         return new PdlDødHendelsePayload.Builder()
                 .hendelseId(pdlDød.getHendelseId())
+                .tidligereHendelseId(pdlDød.getTidligereHendelseId())
                 .type(pdlDød.getHendelseType().getKode())
                 .endringstype(pdlDød.getEndringstype().name())
                 .hendelseOpprettetTid(pdlDød.getOpprettet())

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/tps/PdlDødfødselHendelseTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/tps/PdlDødfødselHendelseTjeneste.java
@@ -46,6 +46,7 @@ public class PdlDødfødselHendelseTjeneste implements HendelseTjeneste<PdlDødf
 
         return new PdlDødfødselHendelsePayload.Builder()
                 .hendelseId(pdlDødfødsel.getHendelseId())
+                .tidligereHendelseId(pdlDødfødsel.getTidligereHendelseId())
                 .type(pdlDødfødsel.getHendelseType().getKode())
                 .endringstype(pdlDødfødsel.getEndringstype().name())
                 .hendelseOpprettetTid(pdlDødfødsel.getOpprettet())

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/tps/PdlFødselHendelseTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/feed/tps/PdlFødselHendelseTjeneste.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.abonnent.feed.tps;
 import static no.nav.foreldrepenger.abonnent.feed.tps.TpsHendelseHjelper.hentUtAktørIderFraString;
 import static no.nav.foreldrepenger.abonnent.feed.tps.TpsHendelseHjelper.optionalStringTilLocalDate;
 
+import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -48,6 +49,7 @@ public class PdlFødselHendelseTjeneste implements HendelseTjeneste<PdlFødselHe
 
         return new PdlFødselHendelsePayload.Builder()
                 .hendelseId(pdlFødsel.getHendelseId())
+                .tidligereHendelseId(pdlFødsel.getTidligereHendelseId())
                 .type(pdlFødsel.getHendelseType().getKode())
                 .endringstype(pdlFødsel.getEndringstype().name())
                 .hendelseOpprettetTid(pdlFødsel.getOpprettet())
@@ -79,6 +81,16 @@ public class PdlFødselHendelseTjeneste implements HendelseTjeneste<PdlFødselHe
     @Override
     public boolean ikkeAtomiskHendelseSkalSendes(PdlFødselHendelsePayload payload) {
         return true;
+    }
+
+    @Override
+    public boolean vurderOmHendelseKanForkastes(PdlFødselHendelsePayload payload) {
+        if (payload.getFødselsdato().isPresent() && payload.getFødselsdato().get().isBefore(LocalDate.now().minusYears(2))) {
+            LOGGER.info("Hendelse {} har fødselsdato {} som var for mer enn to år siden og blir derfor forkastet",
+                    payload.getHendelseId(), payload.getFødselsdato().get());
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/felles/HendelseTjeneste.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/felles/HendelseTjeneste.java
@@ -13,6 +13,10 @@ public interface HendelseTjeneste<T extends HendelsePayload> {
 
     boolean ikkeAtomiskHendelseSkalSendes(T payload);
 
+    default boolean vurderOmHendelseKanForkastes(T payload) {
+        return false;
+    }
+
     KlarForSorteringResultat vurderOmKlarForSortering(T payload);
 
     default void berikHendelseHvisNødvendig(InngåendeHendelse inngåendeHendelse, KlarForSorteringResultat klarForSorteringResultat) {}

--- a/domene/src/test/java/no/nav/foreldrepenger/abonnent/pdl/PdlLeesahHendelseHåndtererTest.java
+++ b/domene/src/test/java/no/nav/foreldrepenger/abonnent/pdl/PdlLeesahHendelseHåndtererTest.java
@@ -75,7 +75,6 @@ public class PdlLeesahHendelseHåndtererTest {
         assertThat(inngåendeHendelse.getHåndtertStatus()).isEqualTo(HåndtertStatusType.MOTTATT);
         assertThat(inngåendeHendelse.getFeedKode()).isEqualTo(FeedKode.PDL);
         assertThat(inngåendeHendelse.getType()).isEqualTo(HendelseType.PDL_DØD_OPPRETTET);
-        assertThat(inngåendeHendelse.getHåndteresEtterTidspunkt()).isNotNull();
 
         ProsessTaskData prosessTaskData = taskCaptor.getValue();
         assertThat(prosessTaskData.getTaskType()).isEqualTo(VurderSorteringTask.TASKNAME);

--- a/migreringer/src/main/resources/db/migration/defaultDS/5.0/V5.0_09__TFP-3114_kobling_id_med_UUID.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/5.0/V5.0_09__TFP-3114_kobling_id_med_UUID.sql
@@ -1,0 +1,3 @@
+alter table INNGAAENDE_HENDELSE add (TIDLIGERE_HENDELSE_ID varchar2(100 char));
+update INNGAAENDE_HENDELSE set TIDLIGERE_HENDELSE_ID = KOBLING_ID;
+comment on column INNGAAENDE_HENDELSE.TIDLIGERE_HENDELSE_ID is 'Hendelsen er knyttet opp mot en tidligere hendelse som har denne verdien som HENDELSE_ID, aktuelt for eksempel ved korrigeringer';


### PR DESCRIPTION
…ort før grovsortering. Det ubrukte feltet koblingId (fra Infotrygd-feed) er endret fra Long til String for å kunne inneholde tidligereHendelseId (UUID), som kommer på koblede PDL-hendelser. Videre er feltet håndteresEtterTidspunkt tatt i bruk for å lagre neste kjøring for VurderSorteringTask, slik at dette kan slås opp uten å kjøre treg spørring mot prosesstask når det senere skal sikres at koblede hendelser blir håndtert i riktig rekkefølge.

SQLer til patch-bestilling når dette er deployet:
`update inngaaende_hendelse set haandteres_etter = (
  select nvl(neste_kjoering_etter, siste_kjoering_plukk_ts)
  from prosess_task where task_parametere like '%'||hendelse_id||'%'
  and task_type = 'hendelser.vurderSortering' and id = (
    select max(id) from prosess_task where task_parametere like '%'||hendelse_id||'%' and task_type = 'hendelser.vurderSortering')
  )
  where feed_kode = 'KAFKA_PDL'
  and haandteres_etter > to_date('2070-01-01', 'YYYY-MM-DD');`

`update inngaaende_hendelse a set a.tidligere_hendelse_id = (
  select regexp_substr(b.payload, '^.*(tidligereHendelseId":")([0-9a-z\-]{36}+)".*', 1, 1, '', 2)
  from inngaaende_hendelse b
  where b.id = a.id
  )
where a.payload like '%tidligereHendelseId%'
and a.feed_kode = 'KAFKA_PDL'
and a.tidligere_hendelse_id is null;`