### PR TITLE
Oppdatere felles, legg inn søppeltømming

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
 
       - name: Setup maven
-        uses: whelk-io/maven-settings-xml-action@v20
+        uses: whelk-io/maven-settings-xml-action@v21
         with:
           repositories: '[{ "id": "github", "name": "github", "url": "https://maven.pkg.github.com/${{ github.repository }}", "releases": { "enabled": "true" }, "snapshots": { "enabled": "false" } }]'
           servers: '[{ "id": "github", "username": "${{ github.actor }}", "password": "${{ secrets.GITHUB_TOKEN }}" }]'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
 
       - name: Setup maven
-        uses: whelk-io/maven-settings-xml-action@v20
+        uses: whelk-io/maven-settings-xml-action@v21
         with:
           repositories: '[{ "id": "github", "name": "github", "url": "https://maven.pkg.github.com/${{ github.repository }}", "releases": { "enabled": "true" }, "snapshots": { "enabled": "false" } }]'
           servers: '[{ "id": "github", "username": "${{ github.actor }}", "password": "${{ secrets.READER_TOKEN }}" }]'
@@ -63,7 +63,7 @@ jobs:
           DATABASE_SERVICE: XEPDB1
 
       - name: Login to GitHub Packages Docker Registry
-        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # Use commit-sha1 instead of tag for security concerns
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # Use commit-sha1 instead of tag for security concerns
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Slash command dispatch
-        uses: peter-evans/slash-command-dispatch@v3.0.0
+        uses: peter-evans/slash-command-dispatch@v3.0.1
         with:
           token: ${{ secrets.NOTIFICATION }} # Må ha PAT for å sjekke tilgang for denne actionen.. Bytte?
           commands: promote # matcher repository dispatch med navent 'promote-command'

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: snyk/actions/setup@master
 
       - name: Setup maven
-        uses: whelk-io/maven-settings-xml-action@v20
+        uses: whelk-io/maven-settings-xml-action@v21
         with:
           repositories: '[{ "id": "github", "name": "github", "url": "https://maven.pkg.github.com/${{ github.repository }}", "releases": { "enabled": "true" }, "snapshots": { "enabled": "false" } }]'
           servers: '[{ "id": "github", "username": "${{ github.actor }}", "password": "${{ secrets.READER_TOKEN }}" }]'

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/felles/tjeneste/HendelseRepository.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/felles/tjeneste/HendelseRepository.java
@@ -126,4 +126,15 @@ public class HendelseRepository {
         }
         return Optional.of(resultater.get(0));
     }
+
+    public int slettIrrelevanteHendelser() {
+        int tps = entityManager.createNativeQuery("DELETE FROM INNGAAENDE_HENDELSE WHERE kilde <> :pdlkilde")
+            .setParameter("pdlkilde", HendelseKilde.PDL.getKode())
+            .executeUpdate();
+        int deletedRows = entityManager.createNativeQuery("DELETE FROM INNGAAENDE_HENDELSE WHERE payload is null and haandtert_status = :handtert")
+            .setParameter("handtert", HåndtertStatusType.HÅNDTERT.getKode())
+            .executeUpdate();
+        entityManager.flush();
+        return tps + deletedRows;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>no.nav.foreldrepenger.felles</groupId>
         <artifactId>fp-bom</artifactId>
-        <version>0.3.6</version>
+        <version>0.3.7</version>
     </parent>
 
     <groupId>no.nav.foreldrepenger.abonnent</groupId>
@@ -26,8 +26,8 @@
         <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
         <sonar.projectKey>navikt_fpabonnent</sonar.projectKey>
 
-        <felles.version>4.2.3</felles.version>
-        <prosesstask.version>3.1.11</prosesstask.version>
+        <felles.version>4.2.7</felles.version>
+        <prosesstask.version>3.1.12</prosesstask.version>
         <fp-kontrakter.version>6.1.27</fp-kontrakter.version>
 
         <!-- Eksterne -->

--- a/web/src/main/java/no/nav/foreldrepenger/abonnent/web/app/batch/SlettGamleTasksBatchTask.java
+++ b/web/src/main/java/no/nav/foreldrepenger/abonnent/web/app/batch/SlettGamleTasksBatchTask.java
@@ -13,21 +13,21 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 @Dependent
-@ProsessTask(value = "retry.feiledeTasks", cronExpression = "0 20 7 * * *", maxFailedRuns = 1)
-public class RekjørFeiledeTasksBatchTask implements ProsessTaskHandler {
+@ProsessTask(value = "retry.feiledeTasks", cronExpression = "0 20 2 * * *", maxFailedRuns = 1)
+public class SlettGamleTasksBatchTask implements ProsessTaskHandler {
 
-    private static final Logger LOG = LoggerFactory.getLogger(RekjørFeiledeTasksBatchTask.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SlettGamleTasksBatchTask.class);
 
     private final ProsessTaskTjeneste prosessTaskTjeneste;
 
     @Inject
-    public RekjørFeiledeTasksBatchTask(ProsessTaskTjeneste prosessTaskTjeneste) {
+    public SlettGamleTasksBatchTask(ProsessTaskTjeneste prosessTaskTjeneste) {
         this.prosessTaskTjeneste = prosessTaskTjeneste;
     }
 
     @Override
     public void doTask(ProsessTaskData prosessTaskData) {
-        var rekjørAlleFeiledeTasks = prosessTaskTjeneste.restartAlleFeiledeTasks();
-        LOG.info("Rekjører alle feilede tasks. {} tasks ble oppdatert.", rekjørAlleFeiledeTasks);
+        var slettet = prosessTaskTjeneste.slettÅrsgamleFerdige();
+        LOG.info("Slettet {} tasks som er over ett år gamle.", slettet);
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/abonnent/web/app/batch/SlettIrrelevanteHendelserBatchTask.java
+++ b/web/src/main/java/no/nav/foreldrepenger/abonnent/web/app/batch/SlettIrrelevanteHendelserBatchTask.java
@@ -1,0 +1,33 @@
+package no.nav.foreldrepenger.abonnent.web.app.batch;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.abonnent.felles.tjeneste.HendelseRepository;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
+
+@ApplicationScoped
+@ProsessTask(value = "retry.feiledeTasks", cronExpression = "0 1 2 * * *", maxFailedRuns = 1)
+public class SlettIrrelevanteHendelserBatchTask implements ProsessTaskHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SlettIrrelevanteHendelserBatchTask.class);
+
+    private HendelseRepository hendelseRepository;
+
+    @Inject
+    public SlettIrrelevanteHendelserBatchTask(HendelseRepository hendelseRepository) {
+        this.hendelseRepository = hendelseRepository;
+    }
+
+    @Override
+    public void doTask(ProsessTaskData prosessTaskData) {
+        var slettet = hendelseRepository.slettIrrelevanteHendelser();
+        LOG.info("Slettet {} tasks som er over ett år gamle.", slettet);
+    }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/abonnent/web/app/exceptions/ConstraintViolationMapper.java
+++ b/web/src/main/java/no/nav/foreldrepenger/abonnent/web/app/exceptions/ConstraintViolationMapper.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 
 public class ConstraintViolationMapper implements ExceptionMapper<ConstraintViolationException> {
 
-    private static final Logger log = LoggerFactory.getLogger(ConstraintViolationMapper.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ConstraintViolationMapper.class);
 
     @Override
     public Response toResponse(ConstraintViolationException exception) {
@@ -33,7 +33,7 @@ public class ConstraintViolationMapper implements ExceptionMapper<ConstraintViol
         List<String> feltNavn = feilene.stream().map(FeltFeilDto::navn).collect(Collectors.toList());
 
         var feil = FeltValideringFeil.feltverdiKanIkkeValideres(feltNavn);
-        log.warn(feil.getMessage());
+        LOG.warn(feil.getMessage());
         return Response
                 .status(Response.Status.BAD_REQUEST)
                 .entity(new FeilDto(feil.getMessage(), feilene))

--- a/web/src/main/java/no/nav/foreldrepenger/abonnent/web/app/exceptions/JsonMappingExceptionMapper.java
+++ b/web/src/main/java/no/nav/foreldrepenger/abonnent/web/app/exceptions/JsonMappingExceptionMapper.java
@@ -13,12 +13,12 @@ import no.nav.vedtak.exception.TekniskException;
 
 public class JsonMappingExceptionMapper implements ExceptionMapper<JsonMappingException> {
 
-    private static final Logger log = LoggerFactory.getLogger(JsonMappingExceptionMapper.class);
+    private static final Logger LOG = LoggerFactory.getLogger(JsonMappingExceptionMapper.class);
 
     @Override
     public Response toResponse(JsonMappingException exception) {
         TekniskException tekniskException = new TekniskException("FP-252294", "JSON-mapping feil", exception);
-        log.warn(tekniskException.getMessage());
+        LOG.warn(tekniskException.getMessage());
         return Response
                 .status(Response.Status.BAD_REQUEST)
                 .entity(new FeilDto(tekniskException.getMessage()))

--- a/web/src/main/java/no/nav/foreldrepenger/abonnent/web/app/exceptions/JsonParseExceptionMapper.java
+++ b/web/src/main/java/no/nav/foreldrepenger/abonnent/web/app/exceptions/JsonParseExceptionMapper.java
@@ -13,12 +13,12 @@ import no.nav.vedtak.exception.TekniskException;
 
 public class JsonParseExceptionMapper implements ExceptionMapper<JsonParseException> {
 
-    private static final Logger log = LoggerFactory.getLogger(JsonParseExceptionMapper.class);
+    private static final Logger LOG = LoggerFactory.getLogger(JsonParseExceptionMapper.class);
 
     @Override
     public Response toResponse(JsonParseException exception) {
         TekniskException tekniskException = new TekniskException("FP-299955", String.format("JSON-parsing feil: %s", exception.getMessage()), exception);
-        log.warn(tekniskException.getMessage());
+        LOG.warn(tekniskException.getMessage());
         return Response
                 .status(Response.Status.BAD_REQUEST)
                 .entity(new FeilDto(tekniskException.getMessage()))

--- a/web/src/test/java/no/nav/foreldrepenger/abonnent/web/app/IndexClasses.java
+++ b/web/src/test/java/no/nav/foreldrepenger/abonnent/web/app/IndexClasses.java
@@ -30,7 +30,7 @@ import org.slf4j.Logger;
 
 /** Henter persistert index (hvis generert) eller genererer index for angitt location (typisk matcher en jar/war fil). */
 public class IndexClasses {
-    private static final Logger log = org.slf4j.LoggerFactory.getLogger(IndexClasses.class);
+    private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(IndexClasses.class);
 
     private static final ConcurrentMap<URI, IndexClasses> INDEXES = new ConcurrentHashMap<>();
 
@@ -127,7 +127,7 @@ public class IndexClasses {
                 try {
                     jsonTypes.add(Class.forName(className));
                 } catch (ClassNotFoundException e) {
-                    log.error("Kan ikke finne klasse i Classpath, som funnet i Jandex index", e);// NOSONAR
+                    LOG.error("Kan ikke finne klasse i Classpath, som funnet i Jandex index", e);// NOSONAR
                 }
             }
         }
@@ -154,7 +154,7 @@ public class IndexClasses {
                     }
                 }
             } catch (ClassNotFoundException e) {
-                log.error("Kan ikke finne klasse i Classpath, som funnet i Jandex index", e);// NOSONAR
+                LOG.error("Kan ikke finne klasse i Classpath, som funnet i Jandex index", e);// NOSONAR
             }
         }
         return cls;


### PR DESCRIPTION
Oppdatere fellesbibliotek
Søppeltømme 1 går gamle ferdig tasks og hendelser som ikke ble sendt inn til fpsak
Resten av de prosesserte hendelsene beholdes pga kjeding av endringer.