### PR TITLE
Legger på AD grupper som kan kreve OBO tokens fra abonnent

### DIFF
--- a/.deploy/dev-fss-teamforeldrepenger.json
+++ b/.deploy/dev-fss-teamforeldrepenger.json
@@ -13,6 +13,9 @@
 	"env": {
 		"APPD_ENABLED": "false"
     },
+	"groups": [
+		"f1b82579-c5b5-4617-9673-8ace5ff67f63"
+	],
 	"AZURE_IAC_RULES": [
 		{
 			"app": "fp-swagger",

--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -65,20 +65,24 @@ spec:
         extra:
           - "NAVident"
           - "azp_name"
+        groups:
+          {{#each groups as |group|}}
+          - id: "{{group}}"
+          {{/each}}
   {{#if AZURE_IAC_RULES}}
   accessPolicy:
-      inbound:
-        rules:
-        {{#each AZURE_IAC_RULES}}
-           - application: {{app}}
-             namespace: {{namespace}}
-             cluster: {{cluster}}
-             {{#if scopes}}
-             permissions:
-               scopes:
-               {{#each scopes}}
-               - "{{this}}"
-               {{/each}}
-             {{/if}}
-   {{/each}}
+    inbound:
+      rules:
+      {{#each AZURE_IAC_RULES}}
+      - application: {{app}}
+        namespace: {{namespace}}
+        cluster: {{cluster}}
+        {{#if scopes}}
+        permissions:
+          scopes:
+            {{#each scopes}}
+            - "{{this}}"
+            {{/each}}
+        {{/if}}
+      {{/each}}
   {{/if}}

--- a/.deploy/prod-fss-teamforeldrepenger.json
+++ b/.deploy/prod-fss-teamforeldrepenger.json
@@ -13,6 +13,9 @@
 	"env": {
 		"APPD_ENABLED": "true"
 	},
+	"groups": [
+		"0d226374-4748-4367-a38a-062dcad70034"
+	],
 	"AZURE_IAC_RULES": [
 		{
 			"app": "fp-swagger",

--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ Applikasjonen tar inn hendelser fra potensielt flere kilder og videresender diss
 Spørsmål knyttet til koden eller prosjektet kan rettes til:
 * nav.team.foreldrepenger@nav.no
 * #teamforeldrepenger
+
+### Sikkerhet
+Det er mulig å kalle tjenesten med bruk av følgende tokens
+- Azure CC
+- Azure OBO med følgende rettigheter:
+    - fpsak-drift

--- a/web/src/main/resources/application-dev-fss.properties
+++ b/web/src/main/resources/application-dev-fss.properties
@@ -1,0 +1,3 @@
+## Sikkerhet
+# OIDC/STS
+oidc.sts.well.known.url=https://security-token-service.nais.preprod.local/.well-known/openid-configuration

--- a/web/src/main/resources/application-dev-fss.properties
+++ b/web/src/main/resources/application-dev-fss.properties
@@ -1,6 +1,0 @@
-## Sikkerhet
-# OIDC/STS
-oidc.sts.well.known.url=https://security-token-service.nais.preprod.local/.well-known/openid-configuration
-
-# Kafka
-kafka.pdl.leesah.topic=pdl.leesah-v1

--- a/web/src/main/resources/application-prod-fss.properties
+++ b/web/src/main/resources/application-prod-fss.properties
@@ -1,6 +1,0 @@
-## Sikkerhet
-# OIDC/STS
-oidc.sts.well.known.url=https://security-token-service.nais.adeo.no/.well-known/openid-configuration
-
-# Kafka
-kafka.pdl.leesah.topic=pdl.leesah-v1

--- a/web/src/main/resources/application-prod-fss.properties
+++ b/web/src/main/resources/application-prod-fss.properties
@@ -1,0 +1,3 @@
+## Sikkerhet
+# OIDC/STS
+oidc.sts.well.known.url=https://security-token-service.nais.adeo.no/.well-known/openid-configuration

--- a/web/src/main/resources/application.properties
+++ b/web/src/main/resources/application.properties
@@ -18,3 +18,6 @@ abac.attributt.drift=no.nav.abac.attributter.foreldrepenger.drift
 
 # PDL
 pdl.base.url=http://pdl-api.pdl/graphql
+
+# Kafka
+kafka.pdl.leesah.topic=pdl.leesah-v1

--- a/web/src/test/resources/application-local.properties
+++ b/web/src/test/resources/application-local.properties
@@ -9,10 +9,6 @@ pip.users=im-just-a-fake-code,srvfpoppdrag,srvfplos,srvfptilbake,srvfpformidling
 systembruker.username=vtp
 systembruker.password=vtp
 
-## Sikkerhet
-# OIDC/STS
-oidc.sts.well.known.url=http://localhost:8060/rest/v1/sts/.well-known/openid-configuration
-
 defaultDS.url=jdbc:oracle:thin:@//localhost:1521/XE
 defaultDS.username=fpabonnent
 defaultDS.password=fpabonnent

--- a/web/src/test/resources/application-local.properties
+++ b/web/src/test/resources/application-local.properties
@@ -9,6 +9,10 @@ pip.users=im-just-a-fake-code,srvfpoppdrag,srvfplos,srvfptilbake,srvfpformidling
 systembruker.username=vtp
 systembruker.password=vtp
 
+## Sikkerhet
+# OIDC/STS
+oidc.sts.well.known.url=http://localhost:8060/rest/v1/sts/.well-known/openid-configuration
+
 defaultDS.url=jdbc:oracle:thin:@//localhost:1521/XE
 defaultDS.username=fpabonnent
 defaultDS.password=fpabonnent


### PR DESCRIPTION
Enforcet endring av NAIS https://nav-it.slack.com/archives/C01DE3M9YBV/p1674475818557619

Per i dag er det brukere fra følgende azure grupper som får lov å kommunisere med fpabonnent med en OBO:
- fpsak-drift (swagger)