### PR TITLE
Fjerner STS støtte. Bumper commons-codecs til å fikse en CVE.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,12 @@
             </dependency>
 
             <!-- Kafka -->
+            <!-- Fikser https://github.com/navikt/fpabonnent/security/dependabot/10 - kan fjernes om avro bumper selv. -->
+            <dependency>
+                <artifactId>commons-compress</artifactId>
+                <groupId>org.apache.commons</groupId>
+                <version>1.24.0</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro</artifactId>

--- a/web/src/main/resources/application-dev-fss.properties
+++ b/web/src/main/resources/application-dev-fss.properties
@@ -1,5 +1,1 @@
-## Sikkerhet
-# OIDC/STS
-oidc.sts.well.known.url=https://security-token-service.nais.preprod.local/.well-known/openid-configuration
-
 pdl.scopes=api://dev-fss.pdl.pdl-api/.default

--- a/web/src/main/resources/application-prod-fss.properties
+++ b/web/src/main/resources/application-prod-fss.properties
@@ -1,5 +1,1 @@
-## Sikkerhet
-# OIDC/STS
-oidc.sts.well.known.url=https://security-token-service.nais.adeo.no/.well-known/openid-configuration
-
 pdl.scopes=api://prod-fss.pdl.pdl-api/.default


### PR DESCRIPTION
Regner at STS ikke brukes siden det er kun en Azure app.