### PR TITLE
Pilot av standardoppsett kafkaconsumer

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/pdl/kafka/KafkaConsumerManager.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/pdl/kafka/KafkaConsumerManager.java
@@ -1,0 +1,127 @@
+package no.nav.foreldrepenger.abonnent.pdl.kafka;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.errors.WakeupException;
+
+public class KafkaConsumerManager<K,V> {
+
+
+    private final List<KafkaMessageHandler<K,V>> handlers;
+    private final List<KafkaConsumerLoop<K,V>> consumers = new ArrayList<>();
+
+    public KafkaConsumerManager(List<KafkaMessageHandler<K, V>> handlers) {
+        this.handlers = handlers;
+    }
+
+    public void start(BiConsumer<String, Throwable> errorlogger) {
+        consumers.addAll(handlers.stream().map(KafkaConsumerLoop::new).toList());
+        consumers.forEach(c -> {
+            var ct = new Thread(c, "KC-" + c.handler().groupId());
+            ct.setUncaughtExceptionHandler((t, e) -> { errorlogger.accept(c.handler().topic(), e); stop(); });
+            ct.start();
+        });
+        Runtime.getRuntime().addShutdownHook(new Thread(new KafkaConsumerCloser<>(consumers)));
+    }
+
+    public void stop() {
+        consumers.forEach(KafkaConsumerLoop::shutdown);
+        var timeout = LocalDateTime.now().plusSeconds(11);
+        while (!allStopped() && LocalDateTime.now().isBefore(timeout)) {
+            try {
+                Thread.sleep(Duration.ofSeconds(1));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    public boolean allRunning() {
+        return consumers.stream().allMatch(KafkaConsumerLoop::isRunning);
+    }
+
+    public boolean allStopped() {
+        return consumers.stream().allMatch(KafkaConsumerLoop::isStopped);
+    }
+
+    public String topicNames() {
+        return handlers.stream().map(KafkaMessageHandler::topic).collect(Collectors.joining(","));
+    }
+
+    private record KafkaConsumerCloser<K,V>(List<KafkaConsumerLoop<K,V>> consumers) implements Runnable {
+        @Override
+        public void run() {
+            consumers.forEach(KafkaConsumerLoop::shutdown);
+        }
+    }
+
+    public static class KafkaConsumerLoop<K,V> implements Runnable {
+
+        private static final Duration POLL_TIMEOUT = Duration.ofMillis(100);
+        private static final Duration CLOSE_TIMEOUT = Duration.ofSeconds(10);
+        private enum ConsumerState { UNINITIALIZED, RUNNING, STOPPING, STOPPED }
+        private static final int RUNNING = ConsumerState.RUNNING.hashCode();
+
+        private final KafkaMessageHandler<K, V> handler;
+        private KafkaConsumer<K, V> consumer;
+        private final AtomicInteger running = new AtomicInteger(ConsumerState.UNINITIALIZED.hashCode());
+
+        public KafkaConsumerLoop(KafkaMessageHandler<K,V> handler) {
+            this.handler = handler;
+        }
+        @Override
+        public void run() {
+            try(var key = handler.keyDeserializer().get(); var value = handler.valueDeserializer().get()) {
+                var props = LokalKafkaProperties.forConsumerGenericValue(handler.groupId(), key, value, handler.autoOffsetReset());
+                consumer = new KafkaConsumer<>(props, key, value);
+                consumer.subscribe(List.of(handler.topic()));
+                running.set(RUNNING);
+                while (running.get() == RUNNING) {
+                    var records = consumer.poll(POLL_TIMEOUT);
+                    // Hvis man vil komplisere ting så kan man håndtere både OffsetCommit og DBcommit i en Transcational handleRecords.
+                    // handleRecords må ta inn alle som er pollet (records) og 2 callbacks som a) legger til konsumert og b) commitAsync(konsumert)
+                    for (var record : records) {
+                        handler.handleRecord(record.key(), record.value());
+                    }
+                }
+            } catch (WakeupException e) {
+                // ignore for shutdown
+            } finally {
+                if (consumer != null) {
+                    consumer.close(CLOSE_TIMEOUT);
+                }
+                running.set(ConsumerState.STOPPED.hashCode());
+            }
+        }
+
+        public void shutdown() {
+            if (running.get() == RUNNING) {
+                running.set(ConsumerState.STOPPING.hashCode());
+            } else {
+                running.set(ConsumerState.STOPPED.hashCode());
+            }
+            if (consumer != null) {
+                consumer.wakeup();
+            }
+        }
+
+        public KafkaMessageHandler<K, V> handler() {
+            return handler;
+        }
+
+        public boolean isRunning() {
+            return running.get() == RUNNING;
+        }
+
+        public boolean isStopped() {
+            return running.get() == ConsumerState.STOPPED.hashCode();
+        }
+    }
+}

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/pdl/kafka/KafkaMessageHandler.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/pdl/kafka/KafkaMessageHandler.java
@@ -1,0 +1,35 @@
+package no.nav.foreldrepenger.abonnent.pdl.kafka;
+
+import java.util.function.Supplier;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+
+public interface KafkaMessageHandler<K,V> {
+
+    void handleRecord(K key, V value);
+
+    // Configuration
+    String topic();
+    String groupId(); // Keep stable (or it will read from autoOffsetReset()
+    default String autoOffsetReset() {
+        return "earliest";
+    }
+
+    // Deserialization - should be configured (Avro). Provided as Supplier to handle Closeable
+    Supplier<Deserializer<K>> keyDeserializer();
+    Supplier<Deserializer<V>> valueDeserializer();
+
+    interface KafkaStringMessageHandler extends KafkaMessageHandler<String, String> {
+
+        default Supplier<Deserializer<String>> keyDeserializer() {
+            return StringDeserializer::new;
+        }
+
+        default Supplier<Deserializer<String>> valueDeserializer() {
+            return StringDeserializer::new;
+        }
+    }
+
+
+}

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/pdl/kafka/LokalKafkaProperties.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/pdl/kafka/LokalKafkaProperties.java
@@ -1,0 +1,82 @@
+package no.nav.foreldrepenger.abonnent.pdl.kafka;
+
+import java.util.Optional;
+import java.util.Properties;
+import java.util.UUID;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+
+import no.nav.foreldrepenger.konfig.Environment;
+
+public class LokalKafkaProperties {
+
+    private static final Environment ENV = Environment.current();
+    private static final boolean IS_DEPLOYMENT = ENV.isProd() || ENV.isDev();
+    private static final String APPLICATION_NAME = ENV.getNaisAppName();
+
+    private LokalKafkaProperties() {
+    }
+
+    // Alle som konsumerer Json-meldinger
+    public static Properties forConsumerStringValue(String groupId) {
+        return forConsumerGenericValue(groupId, new StringDeserializer(), new StringDeserializer(), "earliest");
+    }
+
+    public static <K,V> Properties forConsumerGenericValue(String groupId, Deserializer<K> valueKey, Deserializer<V> valueSerde, String offsetReset) {
+        final Properties props = new Properties();
+
+        props.put(CommonClientConfigs.GROUP_ID_CONFIG, groupId);
+        props.put(CommonClientConfigs.CLIENT_ID_CONFIG, generateClientId());
+        props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, getAivenConfig("KAFKA_BROKERS"));
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, offsetReset);
+
+        putSecurity(props);
+
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, valueKey.getClass());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueSerde.getClass());
+
+        // Polling
+        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "100"); // Unngå store Tx dersom alle prosesseres innen samme Tx. Default 500
+        props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, "100000"); // Gir inntil 1s pr record. Default er 600 ms/record
+
+        return props;
+    }
+
+
+    private static String getAivenConfig(String property) {
+        return Optional.ofNullable(ENV.getProperty(property))
+            .orElseGet(() -> ENV.getProperty(property.toLowerCase().replace('_', '.')));
+    }
+
+    private static String generateClientId() {
+        return APPLICATION_NAME + "-" + UUID.randomUUID();
+    }
+
+    private static void putSecurity(Properties props) {
+        if (IS_DEPLOYMENT) {
+            var credStorePassword = getAivenConfig("KAFKA_CREDSTORE_PASSWORD");
+            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name);
+            props.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");
+            props.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "jks");
+            props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, getAivenConfig("KAFKA_TRUSTSTORE_PATH"));
+            props.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, credStorePassword);
+            props.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, "PKCS12");
+            props.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, getAivenConfig("KAFKA_KEYSTORE_PATH"));
+            props.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, credStorePassword);
+        } else {
+            props.setProperty(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_SSL.name);
+            props.setProperty(SaslConfigs.SASL_MECHANISM, "PLAIN");
+            String jaasTemplate = "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"%s\" password=\"%s\";";
+            String jaasCfg = String.format(jaasTemplate, "vtp", "vtp");
+            props.setProperty(SaslConfigs.SASL_JAAS_CONFIG, jaasCfg);
+        }
+    }
+
+
+}

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/pdl/kafka/PdlLeesahHendelseConsumers.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/pdl/kafka/PdlLeesahHendelseConsumers.java
@@ -1,0 +1,51 @@
+package no.nav.foreldrepenger.abonnent.pdl.kafka;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import no.nav.person.pdl.leesah.Personhendelse;
+import no.nav.vedtak.log.metrics.Controllable;
+import no.nav.vedtak.log.metrics.LiveAndReadinessAware;
+
+@ApplicationScoped
+public class PdlLeesahHendelseConsumers implements LiveAndReadinessAware, Controllable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PdlLeesahHendelseConsumers.class);
+
+    private KafkaConsumerManager<String, Personhendelse> kcm;
+
+    PdlLeesahHendelseConsumers() {
+    }
+
+    @Inject
+    public PdlLeesahHendelseConsumers(PdlLeesahHendelseHåndterer håndterer) {
+        this.kcm = new KafkaConsumerManager<>(List.of(håndterer));
+    }
+
+    @Override
+    public boolean isAlive() {
+        return kcm.allRunning();
+    }
+
+    @Override
+    public boolean isReady() {
+        return isAlive();
+    }
+
+    @Override
+    public void start() {
+        LOG.info("Starter konsumering av topics={}", kcm.topicNames());
+        kcm.start((t, e) -> LOG.error("{} :: Caught exception in stream, exiting", t, e));
+    }
+
+    @Override
+    public void stop() {
+        LOG.info("Starter shutdown av topics={} med 10 sekunder timeout", kcm.topicNames());
+        kcm.stop();
+    }
+
+}

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/pdl/kafka/PdlLeesahHendelseStream.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/pdl/kafka/PdlLeesahHendelseStream.java
@@ -4,11 +4,6 @@ import static org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.St
 
 import java.time.Duration;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
-
-import no.nav.vedtak.log.metrics.LiveAndReadinessAware;
-
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
@@ -16,13 +11,14 @@ import org.apache.kafka.streams.kstream.Consumed;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import no.nav.foreldrepenger.konfig.KonfigVerdi;
 import no.nav.person.pdl.leesah.Personhendelse;
 import no.nav.vedtak.felles.integrasjon.kafka.KafkaProperties;
-import no.nav.vedtak.log.metrics.Controllable;
 
 @ApplicationScoped
-public class PdlLeesahHendelseStream implements LiveAndReadinessAware, Controllable {
+public class PdlLeesahHendelseStream { //implements LiveAndReadinessAware, Controllable {
 
     private static final Logger LOG = LoggerFactory.getLogger(PdlLeesahHendelseStream.class);
 
@@ -52,24 +48,24 @@ public class PdlLeesahHendelseStream implements LiveAndReadinessAware, Controlla
         return new KafkaStreams(builder.build(), KafkaProperties.forStreamsGenericValue(APPLICATION_ID, topic.serdeValue()));
     }
 
-    @Override
+    //@Override
     public boolean isAlive() {
         return (stream != null) && stream.state().isRunningOrRebalancing();
     }
 
-    @Override
+    //@Override
     public boolean isReady() {
         return isAlive();
     }
 
-    @Override
+    //@Override
     public void start() {
         addShutdownHooks();
         stream.start();
         LOG.info("Starter konsumering av topic={}, tilstand={}", getTopicName(), stream.state());
     }
 
-    @Override
+    //@Override
     public void stop() {
         if (stream != null) {
             LOG.info("Starter shutdown av topic={}, tilstand={} med 10 sekunder timeout", getTopicName(), stream.state());

--- a/domene/src/main/java/no/nav/foreldrepenger/abonnent/pdl/kafka/Topic.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/abonnent/pdl/kafka/Topic.java
@@ -28,15 +28,24 @@ record Topic<K, V>(String topic, Serde<K> serdeKey, Serde<V> serdeValue) {
     @SuppressWarnings("resource")
     static Topic<String, Personhendelse> createConfiguredTopic(String topicName) {
         var configuredTopic = new Topic<>(topicName, Serdes.String(), getSerde());
-        var schemaRegistryUrl = KafkaProperties.getAvroSchemaRegistryURL();
-        if (schemaRegistryUrl != null && !schemaRegistryUrl.isEmpty()) {
-            var schemaMap = Map.of(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl,
-                AbstractKafkaSchemaSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO", AbstractKafkaSchemaSerDeConfig.USER_INFO_CONFIG,
-                KafkaProperties.getAvroSchemaRegistryBasicAuth(), SPECIFIC_AVRO_READER_CONFIG, true);
+        var schemaMap = getSchemaMap();
+        if (!schemaMap.isEmpty()) {
             configuredTopic.serdeKey().configure(schemaMap, true);
             configuredTopic.serdeValue().configure(schemaMap, false);
         }
         return configuredTopic;
+    }
+
+    static Map<String, Object> getSchemaMap() {
+        var schemaRegistryUrl = KafkaProperties.getAvroSchemaRegistryURL();
+        if (schemaRegistryUrl != null && !schemaRegistryUrl.isEmpty()) {
+            return Map.of(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl,
+                AbstractKafkaSchemaSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO",
+                AbstractKafkaSchemaSerDeConfig.USER_INFO_CONFIG, KafkaProperties.getAvroSchemaRegistryBasicAuth(),
+                SPECIFIC_AVRO_READER_CONFIG, true);
+        } else {
+            return Map.of();
+        }
     }
 
     private static Serde<Personhendelse> getSerde() {

--- a/domene/src/test/java/no/nav/foreldrepenger/abonnent/pdl/kafka/PdlLeesahHendelseHåndtererTest.java
+++ b/domene/src/test/java/no/nav/foreldrepenger/abonnent/pdl/kafka/PdlLeesahHendelseHåndtererTest.java
@@ -58,7 +58,7 @@ class PdlLeesahHendelseHåndtererTest {
         when(forsinkelseKonfig.skalForsinkeHendelser()).thenReturn(true);
         forsinkelseTjeneste = new ForsinkelseTjeneste(forsinkelseKonfig, hendelseRepository, new DateUtil());
 
-        hendelseHåndterer = new PdlLeesahHendelseHåndterer(hendelseRepository, new PdlLeesahOversetter(), prosessTaskTjeneste, forsinkelseTjeneste);
+        hendelseHåndterer = new PdlLeesahHendelseHåndterer(hendelseRepository, new PdlLeesahOversetter(), prosessTaskTjeneste, forsinkelseTjeneste, "topic");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,17 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Kafka -->
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>3.7.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-streams</artifactId>
+                <version>3.7.0</version>
+            </dependency>
             <dependency>
                 <groupId>no.nav.foreldrepenger.felles</groupId>
                 <artifactId>fp-bom</artifactId>


### PR DESCRIPTION
Litt omstendelig men har koden liggende klar i fp-felles dersom dette funker.
Tanke - en Controllable har injectet alle instanser av KafkaMessageHandler (må implementeres - litt spesiell for Avro).
Alle KMH sendes til en KafkaConsumerManager - som ved start lager nye tråder med en poll-løkke i hver + shutdown.
Dette er ganske Kafka-lærebok-kode uten oppsett eller magi og kun basic tråd-kode.

Begynte å tenke exactly-once - synke Tx-commits og OffsetCommits (manuell). Det går greit, men er ekstra kompleksitet å forstå.
Vil heller gå en KISS-retning med at-least-once og kreve idempotente (eller low-impact) håndterere (slik det er i dag)

