### PR TITLE
chore: Spre natthendelser ut over dagen

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>no.nav.foreldrepenger.felles</groupId>
         <artifactId>fp-bom</artifactId>
-        <version>3.6.10</version>
+        <version>3.6.11</version>
     </parent>
 
     <groupId>no.nav.foreldrepenger.abonnent</groupId>
@@ -25,11 +25,11 @@
         <sonar.projectName>fp-abonnent</sonar.projectName>
         <sonar.projectKey>navikt_fpabonnent</sonar.projectKey>
 
-        <felles.version>7.5.5</felles.version>
+        <felles.version>7.5.6</felles.version>
 
         <prosesstask.version>5.1.7</prosesstask.version>
 
-        <fp-kontrakter.version>9.3.0</fp-kontrakter.version>
+        <fp-kontrakter.version>9.3.2</fp-kontrakter.version>
 
         <!-- Eksterne -->
         <avro.version>1.12.0</avro.version>
@@ -42,7 +42,7 @@
             <dependency>
                 <groupId>no.nav.foreldrepenger.felles</groupId>
                 <artifactId>fp-bom</artifactId>
-                <version>3.6.10</version>
+                <version>3.6.11</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Sprer hendelser som kommer i helg og om natten bedre utover dagen. Nå håndteres alle i perioden 0630-0659
- Venter minst 24 timer (som før)
- Hendelser i helg/helligdag utsettes hele døgn
- Hendelser etter midnatt får lagt på 7 timer - treffer kontortid
- Hendelser etter 2245 - neste dag justert til kontortid

Dermed unngår vi en store peak tidlig mandag morgen