### PR TITLE
chore: fetch size

### DIFF
--- a/domene/src/main/resources/META-INF/persistence.xml
+++ b/domene/src/main/resources/META-INF/persistence.xml
@@ -14,6 +14,7 @@
             <property name="hibernate.generate_statistics" value="true" />
             <property name="hibernate.connection.autocommit" value="false"/>
             <property name="hibernate.jdbc.use_get_generated_keys" value="true"/>
+            <property name="hibernate.jdbc.fetch_size" value="500"/>
             <property name="hibernate.query.mutation_strategy.global_temporary.create_tables" value="false"/>
             <property name="org.hibernate.flushMode" value="COMMIT"/>
         </properties>


### PR DESCRIPTION
Unngå warning, Oracle default er 10. Denne trenger oppslag av den del hendelser, så setter høyere enn andre